### PR TITLE
added CF dependency

### DIFF
--- a/aws-cloudformation/distributed_architecture/DistributedArchitectureSpokeVpc2Az.yaml
+++ b/aws-cloudformation/distributed_architecture/DistributedArchitectureSpokeVpc2Az.yaml
@@ -399,6 +399,9 @@ Resources:
               - "-app-sg"
 
   Application1:
+    DependsOn:
+    - AddRoute1ApplicationRouteTable1
+    - AddApplication1IgwRouteTable
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref ApplicationAmiId
@@ -456,6 +459,9 @@ Resources:
           echo "</html>" >> /var/www/html/index.html
 
   Application2:
+    DependsOn:
+    - AddRoute2ApplicationRouteTable2
+    - AddApplication2IgwRouteTable
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref ApplicationAmiId


### PR DESCRIPTION
makes sure routing is in place before installing\configuring httpd

*Description of changes:*
When deploying the spoke architecture template the routes needs to be in place before launching the application instances. Otherwise the installation and configuration process of `httpd` failed due to the lack of internet connectivity.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
