### PR TITLE
Update Readme.MD

### DIFF
--- a/aws-cloudformation/distributed_architecture/README.md
+++ b/aws-cloudformation/distributed_architecture/README.md
@@ -2,7 +2,7 @@
 
 ## Welcome
 
-* For more details, refer to blog: **[Scaling network traffic inspection using AWS Gateway Load Balancer](https://aws-blogs-prod.amazon.com/networking-and-content-delivery/scaling-network-traffic-inspection-using-AWS-Gateway-Load-Balancer/)**
+* For more details, refer to blog: **[Scaling network traffic inspection using AWS Gateway Load Balancer](https://aws.amazon.com/blogs/networking-and-content-delivery/scaling-network-traffic-inspection-using-aws-gateway-load-balancer/)**
 
 * This section contains sample AWS Cloudformation templates that demonstrates how to create distributed architecture using AWS Gateway Load Balancer and Gateway Load Balancer Endpoints from templates that are written in YAML.
 


### PR DESCRIPTION
Corrected AWS Blog link from internal link to Public Link

*Issue #, if available:* Link for AWS Blogs is pointing to Internal AWS link which is not accessible. 

*Description of changes:* Link was corrected to Public AWS Blog Link


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
