### PR TITLE
Changed broken links to blog

### DIFF
--- a/aws-cloudformation/distributed_architecture/DistributedArchitectureApplianceVpc2Az.yaml
+++ b/aws-cloudformation/distributed_architecture/DistributedArchitectureApplianceVpc2Az.yaml
@@ -2,7 +2,7 @@
 # Appliance VPC using AWS CloudFormation. 
 
 # For architecture details refer to blog:
-# https://aws-blogs-prod.amazon.com/networking-and-content-delivery/scaling-network-traffic-inspection-using-AWS-Gateway-Load-Balancer/
+# https://aws.amazon.com/blogs/networking-and-content-delivery/scaling-network-traffic-inspection-using-aws-gateway-load-balancer/
 
 # Template uses Amazon Linux 2 instances as appliances behind the GWLB.
 # Configures iptables on instances for hairpin setup. The hairpin setup 

--- a/aws-cloudformation/distributed_architecture/DistributedArchitectureSpokeVpc2Az.yaml
+++ b/aws-cloudformation/distributed_architecture/DistributedArchitectureSpokeVpc2Az.yaml
@@ -1,6 +1,6 @@
 # Following example shows how to create AWS Gateway Load Balancer Spoke VPC
 # using AWS CloudFormation. For more details, refer to blog:
-# https://aws-blogs-prod.amazon.com/networking-and-content-delivery/scaling-network-traffic-inspection-using-AWS-Gateway-Load-Balancer/
+# https://aws.amazon.com/blogs/networking-and-content-delivery/scaling-network-traffic-inspection-using-aws-gateway-load-balancer/
 
 AWSTemplateFormatVersion: "2010-09-09"
 


### PR DESCRIPTION
*Description of changes:*
Hi Team,

the links to the corresponding blogposts in the CFN examples for the distributed architecture were not working, so I switched them to the official link.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
