### PR TITLE
Add support for cross-zone load balancing in appliance config

### DIFF
--- a/aws-cloudformation/centralized_architecture/CentralizedArchitectureApplianceVpc2Az.yaml
+++ b/aws-cloudformation/centralized_architecture/CentralizedArchitectureApplianceVpc2Az.yaml
@@ -628,7 +628,7 @@ Resources:
           export instance_az=$(cat /home/ec2-user/iid |grep 'availability' | awk -F': ' '{print $2}' | awk -F',' '{print $1}');
           export instance_ip=$(cat /home/ec2-user/iid |grep 'privateIp' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
           export instance_region=$(cat /home/ec2-user/iid |grep 'region' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
-          export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
+          # export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
 
           # Start http and configure index.html:
           systemctl start httpd;
@@ -661,8 +661,11 @@ Resources:
           iptables -X;
 
           # Configure nat table to hairpin traffic back to GWLB:
-          iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081;
-          iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE;
+          for gwlb_ip in $(aws ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid --region $instance_region | jq ' .NetworkInterfaces[] | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r)
+          do
+            iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081
+            iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE
+          done
 
           # Save iptables:
           service iptables save;
@@ -721,7 +724,7 @@ Resources:
           export instance_az=$(cat /home/ec2-user/iid |grep 'availability' | awk -F': ' '{print $2}' | awk -F',' '{print $1}');
           export instance_ip=$(cat /home/ec2-user/iid |grep 'privateIp' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
           export instance_region=$(cat /home/ec2-user/iid |grep 'region' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
-          export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
+          # export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
 
           # Start httpd and configure index.html:
           systemctl start httpd;
@@ -754,8 +757,11 @@ Resources:
           iptables -X;
 
           # Configure nat table to hairpin traffic back to GWLB:
-          iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081;
-          iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE;
+          for gwlb_ip in $(aws ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid --region $instance_region | jq ' .NetworkInterfaces[] | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r)
+          do
+            iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081
+            iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE
+          done
 
           # Save iptables:
           service iptables save;

--- a/aws-cloudformation/centralized_architecture/nested-stack/ApplianceVpc2Az.yaml
+++ b/aws-cloudformation/centralized_architecture/nested-stack/ApplianceVpc2Az.yaml
@@ -628,7 +628,7 @@ Resources:
           export instance_az=$(cat /home/ec2-user/iid |grep 'availability' | awk -F': ' '{print $2}' | awk -F',' '{print $1}');
           export instance_ip=$(cat /home/ec2-user/iid |grep 'privateIp' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
           export instance_region=$(cat /home/ec2-user/iid |grep 'region' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
-          export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
+          # export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
 
           # Start http and configure index.html:
           systemctl start httpd;
@@ -661,8 +661,11 @@ Resources:
           iptables -X;
 
           # Configure nat table to hairpin traffic back to GWLB:
-          iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081;
-          iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE;
+          for gwlb_ip in $(aws ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid --region $instance_region | jq ' .NetworkInterfaces[] | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r)
+          do
+            iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081
+            iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE
+          done
 
           # Save iptables:
           service iptables save;
@@ -721,7 +724,7 @@ Resources:
           export instance_az=$(cat /home/ec2-user/iid |grep 'availability' | awk -F': ' '{print $2}' | awk -F',' '{print $1}');
           export instance_ip=$(cat /home/ec2-user/iid |grep 'privateIp' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
           export instance_region=$(cat /home/ec2-user/iid |grep 'region' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
-          export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
+          # export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
 
           # Start httpd and configure index.html:
           systemctl start httpd;
@@ -754,8 +757,11 @@ Resources:
           iptables -X;
 
           # Configure nat table to hairpin traffic back to GWLB:
-          iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081;
-          iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE;
+          for gwlb_ip in $(aws ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid --region $instance_region | jq ' .NetworkInterfaces[] | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r)
+          do
+            iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081
+            iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE
+          done
 
           # Save iptables:
           service iptables save;

--- a/aws-cloudformation/distributed_architecture/DistributedArchitectureApplianceVpc2Az.yaml
+++ b/aws-cloudformation/distributed_architecture/DistributedArchitectureApplianceVpc2Az.yaml
@@ -497,7 +497,7 @@ Resources:
           export instance_az=$(cat /home/ec2-user/iid |grep 'availability' | awk -F': ' '{print $2}' | awk -F',' '{print $1}');
           export instance_ip=$(cat /home/ec2-user/iid |grep 'privateIp' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
           export instance_region=$(cat /home/ec2-user/iid |grep 'region' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
-          export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
+          # export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
 
           # Start http and configure index.html:
           systemctl start httpd;
@@ -530,8 +530,11 @@ Resources:
           iptables -X;
 
           # Configure nat table to hairpin traffic back to GWLB:
-          iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081;
-          iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE;
+          for gwlb_ip in $(aws ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid --region $instance_region | jq ' .NetworkInterfaces[] | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r)
+          do
+            iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081
+            iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE
+          done
 
           # Save iptables:
           service iptables save;
@@ -585,7 +588,7 @@ Resources:
           export instance_az=$(cat /home/ec2-user/iid |grep 'availability' | awk -F': ' '{print $2}' | awk -F',' '{print $1}');
           export instance_ip=$(cat /home/ec2-user/iid |grep 'privateIp' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
           export instance_region=$(cat /home/ec2-user/iid |grep 'region' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
-          export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
+          # export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
 
           # Start httpd and configure index.html:
           systemctl start httpd;
@@ -618,8 +621,11 @@ Resources:
           iptables -X;
 
           # Configure nat table to hairpin traffic back to GWLB:
-          iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081;
-          iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE;
+          for gwlb_ip in $(aws ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid --region $instance_region | jq ' .NetworkInterfaces[] | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r)
+          do
+            iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081
+            iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE
+          done
 
           # Save iptables:
           service iptables save;

--- a/aws-cloudformation/vpc_routing_enhancement_architectures/templates/InspectionVpc.yaml
+++ b/aws-cloudformation/vpc_routing_enhancement_architectures/templates/InspectionVpc.yaml
@@ -627,7 +627,7 @@ Resources:
           export instance_az=$(cat /home/ec2-user/iid |grep 'availability' | awk -F': ' '{print $2}' | awk -F',' '{print $1}');
           export instance_ip=$(cat /home/ec2-user/iid |grep 'privateIp' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
           export instance_region=$(cat /home/ec2-user/iid |grep 'region' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
-          export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
+          # export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
 
           # Start http and configure index.html:
           systemctl enable httpd;
@@ -661,8 +661,11 @@ Resources:
           iptables -X;
 
           # Configure nat table to hairpin traffic back to GWLB:
-          iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081;
-          iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE;
+          for gwlb_ip in $(aws ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid --region $instance_region | jq ' .NetworkInterfaces[] | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r)
+          do
+            iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081
+            iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE
+          done
 
           # Save iptables:
           service iptables save;
@@ -717,7 +720,7 @@ Resources:
           export instance_az=$(cat /home/ec2-user/iid |grep 'availability' | awk -F': ' '{print $2}' | awk -F',' '{print $1}');
           export instance_ip=$(cat /home/ec2-user/iid |grep 'privateIp' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
           export instance_region=$(cat /home/ec2-user/iid |grep 'region' | awk -F': ' '{print $2}' | awk -F',' '{print $1}' | awk -F'"' '{print$2}');
-          export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
+          # export gwlb_ip=$(aws --region $instance_region ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid | jq ' .NetworkInterfaces[] | select(.AvailabilityZone=='$instance_az') | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r);
 
           # Start httpd and configure index.html:
           systemctl enable httpd;
@@ -751,8 +754,11 @@ Resources:
           iptables -X;
 
           # Configure nat table to hairpin traffic back to GWLB:
-          iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081;
-          iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE;
+          for gwlb_ip in $(aws ec2 describe-network-interfaces --filters Name=vpc-id,Values=$instance_vpcid --region $instance_region | jq ' .NetworkInterfaces[] | select(.InterfaceType=="gateway_load_balancer") |.PrivateIpAddress' -r)
+          do
+            iptables -t nat -A PREROUTING -p udp -s $gwlb_ip -d $instance_ip -i eth0 -j DNAT --to-destination $gwlb_ip:6081
+            iptables -t nat -A POSTROUTING -p udp --dport 6081 -s $gwlb_ip -d $gwlb_ip -o eth0 -j MASQUERADE
+          done
 
           # Save iptables:
           service iptables save;


### PR DESCRIPTION
*Issue #, if available:*

Resolves #11 

*Description of changes:*

Updates the `iptables` configuration in the EC2 instance `UserData` to hairpin traffic from both GWLB endpoints. This will allow the appliances to support cross-zone load balancing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
